### PR TITLE
Update filebrowser.monkey2

### DIFF
--- a/modules/mojox/filebrowser.monkey2
+++ b/modules/mojox/filebrowser.monkey2
@@ -5,6 +5,7 @@ Namespace mojox
 #end
 Class FileBrowser Extends TreeView
 
+
 	#rem monkeydoc Invoked when a file is clicked.
 	#end
 	Field FileClicked:Void( path:String )
@@ -39,6 +40,23 @@ Class FileBrowser Extends TreeView
 		
 		Update()
 	End
+	#rem monkeydoc Set what Files should be excluded. Values separated by commas.
+	#end
+	Property ExcludedFile:String()
+		Return _excluded_file
+	Setter(_e:String)
+		_excluded_file=_e
+	End
+	#rem monkeydoc Set what Folders should be excluded. Values separated by commas.
+	#end
+	Property ExcludedFolder:String()
+		Return _excluded_folder
+	Setter(_e:String)
+		_excluded_folder=_e
+	End
+	
+	
+	
 	
 	#rem monkeydoc Root path of browser.
 	#end
@@ -142,25 +160,33 @@ Class FileBrowser Extends TreeView
 		
 		Local dirs:=New Stack<String>
 		Local files:=New Stack<String>
-		
+	
 		For Local f:=Eachin dir
-		
-			Local fpath:=path+f
-			
+			Local fpath:=path+"/"+f
 			Select GetFileType( fpath )
 			Case FileType.Directory
-				dirs.Push( f )
+				for Local ef:=Eachin _excluded_folder.Split(",")
+					If fpath.ToLower().Contains(ef.ToLower())=True f=""
+				Next
+				If f<>"" dirs.Push( f )
 			Default
-				files.Push( f )
+				For Local ef:=Eachin _excluded_file.Split(",")	
+					If f.ToLower().Contains(ef.ToLower())=True f=""
+				Next
+			
+				If f<>""	files.Push( f )
 			End
 		Next
+		
+
 		
 		dirs.Sort()
 		files.Sort()
 		
 		Local i:=0,children:=node.Children
+		Local total_size:=dirs.Length+files.Length
 		
-		While i<dir.Length
+		While i<total_size
 		
 			Local f:=""
 			If i<dirs.Length f=dirs[i] Else f=files[i-dirs.Length]
@@ -223,8 +249,13 @@ Class FileBrowser Extends TreeView
 		Return _fileTypeIcons
 	End
 	
+
+	
 	Private
-	
+
+		
 	Global _fileTypeIcons:StringMap<Image>
-	
+	Global _excluded_file:String
+	Global _excluded_folder:String
 End
+

--- a/src/ted2/fileactions.monkey2
+++ b/src/ted2/fileactions.monkey2
@@ -213,7 +213,7 @@ Class FileActions
 
 			Local path:=MainWindow.RequestFile( "Save As","",True )
 			If Not path Return
-			
+				If CheckValidExtension(path)=False	path=path+".monkey2"
 			Rename( doc,path,True,True )
 		Else
 		
@@ -228,7 +228,7 @@ Class FileActions
 	
 		Local path:=MainWindow.RequestFile( "Save As","",True )
 		If Not path Return 
-		
+			If CheckValidExtension(path)=False	path=path+".monkey2"
 		Rename( doc,path,True,True )
 	End
 	
@@ -240,7 +240,7 @@ Class FileActions
 	
 				Local path:=MainWindow.RequestFile( "Save As","",True )
 				If Not path Return
-				
+					If CheckValidExtension(path)=False	path=path+".monkey2"
 				Rename( doc,path,True,False )
 			Else
 			
@@ -264,3 +264,15 @@ Class FileActions
 		App.Terminate()
 	End
 End
+
+Function CheckValidExtension:Bool(t:String)
+	Local ve:="monkey2,h,hpp,hxx,c,cpp,cxx,m,mm,s,asm,html,js,css,php,md,json,xml,ini,sh,bat,glsl,txt"
+	Local fe:=ExtractExt(t)
+	if fe="" Return false
+	For Local e:=Eachin ve.Split(",")
+		If fe.ToLower()="."+e Return True
+	Next
+	Return false
+
+End Function
+


### PR DESCRIPTION
Added two Property to exclude - when loading a dir structure - some files and folders that contain in the name some strings.
ie: if I don't want to see the xxxx.buildv1.0.3 folders I can use this to 'skip' those items.

Use:

browser:=New FileBrowser
browser.ExcludedFolder="buildv,devtools,bin"
browser.ExcludedFile=".exe,.git"