### PR TITLE
MojoX Toolbar Life Improvement

### DIFF
--- a/modules/mojox/toolbar.monkey2
+++ b/modules/mojox/toolbar.monkey2
@@ -21,11 +21,11 @@ Class ToolBar Extends DockingView
 
 	#rem monkeydoc Creates a new tool bar.
 	#end
-	Method New()
-		Self.New( std.geom.Axis.X )
+	Method New( flip:Bool=False )
+		Self.New( std.geom.Axis.X,flip )
 	End
 	
-	Method New( axis:Axis )
+	Method New( axis:Axis,flip:Bool=False)
 		Style=GetStyle( "ToolBar" )
 		
 		Layout=(axis=Axis.X ? "fill-x" Else "fill-y")
@@ -33,7 +33,8 @@ Class ToolBar Extends DockingView
 		Gravity=New Vec2f( 0,0 )
 		
 		_axis=axis
-		_add=axis=Axis.X ? "left" Else "top"
+		
+		_add=axis=Axis.X ? (flip? "right" Else "left") Else (flip? "bottom" Else "top")
 	End
 	
 	#rem monkeydoc Toolbar axis.


### PR DESCRIPTION
Adds an extra functionality to the toolbar so the anchoring of the added
views can be reversed.

### Added
- You can chose to flip the direction of the default view anchoring 
- You can also chose to flip the axis you'll be on 
     - options: right, left, top, bottom

#### Demo
```monkey2
Local tbar:= new ToolBar(  Axis.x, true ) 
tbar.Gravity = new Vec2f( 0, 1 )
' creates a toolbar with elements on the bottom right 
```