### PR TITLE
[Compile Crash] fixed dots in filename problem

### DIFF
--- a/src/mx2cc/decl.monkey2
+++ b/src/mx2cc/decl.monkey2
@@ -24,7 +24,7 @@ Const DECL_ACCESSMASK:=DECL_PUBLIC|DECL_PRIVATE|DECL_PROTECTED|DECL_INTERNAL
 Class Decl Extends PNode
 
 	Field kind:String
-	Field ident:String
+	Field _ident:String
 	Field flags:Int
 	Field symbol:String
 	Field docs:String
@@ -90,6 +90,12 @@ Class Decl Extends PNode
 	
 	Property IsDefault:Bool()
 		Return (flags & DECL_DEFAULT)<>0
+	End
+	
+	Property ident:String()
+		Return _ident
+	Setter( value:String )
+		_ident=value.Replace(".","_DOT_")
 	End
 	
 	Method ToNode:SNode( scope:Scope ) Virtual

--- a/src/mx2cc/decl.monkey2
+++ b/src/mx2cc/decl.monkey2
@@ -95,7 +95,7 @@ Class Decl Extends PNode
 	Property ident:String()
 		Return _ident
 	Setter( value:String )
-		_ident=value.Replace(".","_DOT_")
+		_ident=value.Replace( ".","_DOT_" )
 	End
 	
 	Method ToNode:SNode( scope:Scope ) Virtual


### PR DESCRIPTION
The problems which were associated with dots in the filenames were linked directly with the translation phase. 

Feedback and improvements wanted :) 

### Problem (issue #213 and issue #307  )
Most if not all of the problems occurred from retrieving a dirty ident value from a `Decl` and using that to inline code during the translation phase. 

### Solution
The solution, the simplest for me to implement, was to add a middle-man step in the code to prevent the translated CPP phase use any dirty values. What I have done is use a dummy `property` which cleans the dirty **dots** on read and return the respective, internal, ident value.


## Tested 
I have tested that this indeed executed with a file with a various amount of dots in the name and it worked.

Example 1: `sn.ake.monkey` _main file_
Example 2: `#Import "at.test.folder/this.file.with.dots.monkey2"` _imported nested file_

sna.ke imported the second example and after running build through Ted it compiled with no yelling. 