### PR TITLE
Removed unused private properties

### DIFF
--- a/modules/mojox/gridview.monkey2
+++ b/modules/mojox/gridview.monkey2
@@ -124,8 +124,6 @@ Class GridView Extends View
 		End
 	End
 	
-	Field _cellw:Int
-	Field _cellh:Int
 	Field _gridw:Int
 	Field _gridh:Int
 	Field _cells:=New Stack<Cell>


### PR DESCRIPTION
Digging through some of the Gridview code I found that these two properties aren't being used at all. Maybe they had a place in there, to begin with, but not anymore?

As far as I can tell, they don't serve a purpose anymore since each cell has its own dimension.