### PR TITLE
small work on docs

### DIFF
--- a/modules/mojo/input/keycodes.monkey2
+++ b/modules/mojo/input/keycodes.monkey2
@@ -3,11 +3,12 @@ Namespace mojo.input
 
 #rem monkeydoc Key codes.
 
-By default, key codes refer to 'virtual' keys. For example, `KEY_W` refers to the key with 'W' printed on it. However, this key may be not
+By default, key codes refer to 'virtual' keys. For example, `Key.W` refers to the key with 'W' printed on it. However, this key may be not
 be in the same physical location on all users' keyboards, due to OS language and keyboard settings.
 
 To deal with this, mojo also provides support for 'raw' keys. A raw key code is simply a virtual key code 'or'ed with the special key code
-`Key.Raw`.
+`Key.Raw`. For example, 'Key.Q|Key.Raw' refers to the key with 'Q' printed on it on a QWERTY keyboard. `Key.Raw` is to be used with the
+[[Keboard]] Class only. For example `Keyboard.KeyPressed(Key.A|Key.Raw)`.
 
 A raw key represents the physical location of a key on US keyboards. For example, `Key.Q|Key.Raw` indicates the key at the top left of the
 'qwerty' (or 'azerty' etc) keys regardless of the current OS settings.

--- a/modules/mojo/input/keycodes.monkey2
+++ b/modules/mojo/input/keycodes.monkey2
@@ -3,8 +3,8 @@ Namespace mojo.input
 
 #rem monkeydoc Key codes.
 
-By default, key codes refer to 'virtual' keys. For example, `Key.W` refers to the key with 'W' printed on it. However, this key may be not
-be in the same physical location on all users' keyboards, due to OS language and keyboard settings.
+By default, key codes refer to 'virtual' keys. For example, `Key.W` refers to the key with 'W' printed on it. However, this key may not be
+in the same physical location on all users' keyboards, due to OS language and keyboard settings.
 
 To deal with this, mojo also provides support for 'raw' keys. A raw key code is simply a virtual key code 'or'ed with the special key code
 `Key.Raw`.

--- a/modules/mojo/input/keycodes.monkey2
+++ b/modules/mojo/input/keycodes.monkey2
@@ -7,11 +7,10 @@ By default, key codes refer to 'virtual' keys. For example, `Key.W` refers to th
 be in the same physical location on all users' keyboards, due to OS language and keyboard settings.
 
 To deal with this, mojo also provides support for 'raw' keys. A raw key code is simply a virtual key code 'or'ed with the special key code
-`Key.Raw`. For example, 'Key.Q|Key.Raw' refers to the key with 'Q' printed on it on a QWERTY keyboard. `Key.Raw` is to be used with the
-[[Keboard]] Class only. For example `Keyboard.KeyPressed(Key.A|Key.Raw)`.
-
+`Key.Raw`.
 A raw key represents the physical location of a key on US keyboards. For example, `Key.Q|Key.Raw` indicates the key at the top left of the
 'qwerty' (or 'azerty' etc) keys regardless of the current OS settings.
+`Key.Raw` is to be used with the [[KeyboardDevice]] Class only. For example `Keyboard.KeyPressed(Key.A|Key.Raw)`.
 
 | Key
 |:---

--- a/modules/monkey/newdocs/language/misc.md
+++ b/modules/monkey/newdocs/language/misc.md
@@ -10,6 +10,8 @@ Inline comments can be done with the `'` character.
 Print "hello!" 'this line prints hello! on the output console
 ```
 
+Multiline comments can be made with the `#Rem` preprocessor. See [[language-reference.preprocessor|preprocessor]]
+
 @#### Line breaks in code
 
 Lines can currently only be split after ‘[‘, ‘(‘ or ‘,’ tokens.
@@ -40,3 +42,14 @@ Hexadecimal numbers can be entered using the $ symbol
 ```
 Local i:=$A0F
 ```
+
+@#### File privacy levels
+
+Privacy levels can be set at file scope:
+
+-`Public` can be accessed from anywhere. It is the default level.
+
+-`Private` can be accessed within the file only.
+
+-`Internal` can be accessed from the same module only.
+

--- a/modules/monkey/newdocs/language/modules.md
+++ b/modules/monkey/newdocs/language/modules.md
@@ -63,6 +63,7 @@ This function is called *after* global variables (including global Consts) have 
 
 Since modules can't have cyclic dependencies, Mains will always execute in the correct order, eg: if module X imports module Y, then module Y's Main is guaranteed to be called before module X's.
 
+You can use the `Internal` keyword at class or file scope to declare module internal accessibility. 
 
 @#### Importing modules
 

--- a/modules/monkey/newdocs/language/pointers.md
+++ b/modules/monkey/newdocs/language/pointers.md
@@ -8,7 +8,7 @@ In Monkey2 pointers are mainly used with external C/C++ code.
 Try not to use pointers unless absolutely necessary. It can lead to bugs if the pointed address is not kept "alive". Pointers to globals are safe, for example.  
 You must have access to the memory you're trying to reach or you'll have a (fatal) memory access violation.
 
-A pointer can point to any kind of type, even garbage collected types. This can lead to bad things too as the garbage collector is not 'aware' of pointers.
+A pointer should not point to a class instance. To get a pointer to your class object, you'll have to cast it to `Void Ptr`. See example below.
 
 @#### Declarations
 
@@ -49,7 +49,7 @@ Note you can use pointer arythmetics with the index operator(`[]`) but you have 
 
 @#### Dereferencing with ->
 
-You can access user defined types fields, methods,.. with the `->` operator. It is equivalent to `[0].`
+You can access a struct fields, methods,.. with the `->` operator. It is equivalent to `[0].`. Note that pointer to class is prohibited.
 
 ```
 Struct str
@@ -72,18 +72,15 @@ You can Cast a pointer and do some explicit conversions with the `Cast` operator
 
 `Cast`<_Type_>(_address_)
 
-An example with a useless conversion from Int to Void to Int:
+An example with a conversion from Class(reference) to Void Ptr to Class:
 ```
-Local i:int=1
+Local foo:=New myFooClass()
 Local myVoidPtr:Void Ptr
 
-myVoidPtr=Cast<Void Ptr>(VarPtr i)
+myVoidPtr=Cast<Void Ptr>(foo)
 
-Local j:int
-Local myIntPtr:Int Ptr
+Local foo2:myFooClass
 
-myIntPtr=Cast<Int Ptr>(myVoidPtr)
-j=myIntPtr[0]
+foo2=Cast<myFooClass>(myVoidPtr)
 ```
-`j` receives the value of `i` but does not have the same address.
-`myIntPtr` and `myVoidPtr` both point to the same address (`VarPtr i`) but have different types.
+"foo" and "foo2" will have the same address(reference). Note that casting to `Void Ptr` is essentially used when dealing with external native code.

--- a/modules/monkey/newdocs/language/pointers.md
+++ b/modules/monkey/newdocs/language/pointers.md
@@ -45,11 +45,11 @@ myPtr=VarPtr i
 Print myPtr[0]
 ```
 Will print 1, the value of `i`.
-Note you can use pointer arythmetics with the index operator(`[]`) but you have to be sure you have access to that part of the memory or you'll get a memory access violation!
+Note you can use pointer arithmetics with the index operator(`[]`) but you have to be sure you have access to that part of the memory or you'll get a memory access violation!
 
 @#### Dereferencing with ->
 
-You can access a struct fields, methods,.. with the `->` operator. It is equivalent to `[0].`. Note that pointer to class is prohibited.
+You can access a struct's fields, methods,.. with the `->` operator. It is equivalent to `[0].`. Note that creating a pointer to class is prohibited.
 
 ```
 Struct str
@@ -83,4 +83,4 @@ Local foo2:myFooClass
 
 foo2=Cast<myFooClass>(myVoidPtr)
 ```
-"foo" and "foo2" will have the same address(reference). Note that casting to `Void Ptr` is essentially used when dealing with external native code.
+"foo" and "foo2" will have the same address(reference). Note that casting to `Void Ptr` is commonly used when dealing with external native code.

--- a/modules/monkey/newdocs/language/user-types.md
+++ b/modules/monkey/newdocs/language/user-types.md
@@ -215,6 +215,8 @@ There are three levels of encapsulation for class and struct members:
 
 -`Private` members can only be accessed by the base class. Code existing in the same source file have acces to `Private` members too.
 
+There is also the `Internal` privacy level, used to declare module internal accessibility.
+
 example:
 ```
 Class Foo


### PR DESCRIPTION
-correction related to problems encountered by discord users
-preventive removing of "class ptr" and suggest to use cast to "void ptr" instead (is a good idea or should it be changed when the prohibition of "class ptr" occurs?)