### PR TITLE
Fixed typo in a Color constructor, alpha wasn't being used

### DIFF
--- a/modules/std/graphics/color.monkey2
+++ b/modules/std/graphics/color.monkey2
@@ -168,7 +168,7 @@ Struct Color
 		Self.r=i
 		Self.g=i
 		Self.b=i
-		Self.a=1
+		Self.a=a
 	End
 	
 	Method New( r:Float,g:Float,b:Float,a:Float=1 )


### PR DESCRIPTION
The old code was using `Self.a=1` in the constructor instead of using the passed parameter. I've swapped that one character.

found by: mingw  on discord.